### PR TITLE
Add in line terminator from Dart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.2.3
+
+* Include lineTerminator from Dart 3.1.0 on platform
+
 # 2.2.2
 * Improve dependency constraints.
 

--- a/lib/src/platform.dart
+++ b/lib/src/platform.dart
@@ -211,4 +211,15 @@ class Platform {
   /// possibly followed by whitespace and other version and
   /// build details.
   static String get version => '';
+
+  /// The current operating system's default line terminator.
+  ///
+  /// The default character sequence that the operating system
+  /// uses to separate or terminate text lines.
+  ///
+  /// The line terminator is currently the single line-feed character,
+  /// U+000A or `"\n"`, on all supported operating systems except Windows,
+  /// which uses the carriage-return + line-feed sequence, U+000D U+000A or
+  /// `"\r\n"`
+  static String get lineTerminator => isWindows ? '\r\n' : '\n';
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: universal_io
-version: 2.2.2
+version: 2.2.3
 description: Cross-platform 'dart:io' that adds browser support for HttpClient and some other
   "dart:io" APIs.
 homepage: https://github.com/dart-io-packages/universal_io


### PR DESCRIPTION
This adds better compatibility for web by mirroring the added property to Platform from Dart:io 